### PR TITLE
Fire Weight Bug Fix

### DIFF
--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/async/AsyncManager.java
@@ -525,7 +525,7 @@ public class AsyncManager extends BukkitRunnable {
                     }
                 }
 
-                if (blockID != 0) {
+                if (blockID != 0 && blockID != 51) {
                     totalNonAirBlocks++;
                 }
                 if (blockID != 0 && blockID != 8 && blockID != 9) {

--- a/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
+++ b/modules/Movecraft/src/main/java/net/countercraft/movecraft/sign/StatusSign.java
@@ -70,7 +70,7 @@ public final class StatusSign implements Listener{
                     fuel += iStack.getAmount() * fuelTypes.get(iStack.getType());
                 }
             }
-            if (blockID != 0) {
+            if (blockID != 0 && blockID != 51) {
                 totalBlocks++;
             }
         }


### PR DESCRIPTION
Fixes a bug where fire counts as a 'weight' block, causing ships to sink from external fires.

<!-- Please fill out the following before submitting your PR. -->
### Describe in detail what your pull request acomplishes

<!-- Delete if not aplicable -->
<!-- If you're fixing an issue, make sure to prefix the linked issue with "fixes". -->
### Related issues:
- 

### Checklist
- [ ] Unit tests <!-- if implementing API utilities, otherwise delete -->
- [ ] Proper internationalization
- [ ] Compiled/tested
